### PR TITLE
Add uptime info plugin and Bats test

### DIFF
--- a/plugins/50_uptime_info.sh
+++ b/plugins/50_uptime_info.sh
@@ -2,6 +2,11 @@
 # Usage: 50_uptime_info.sh <arch>
 ARCH="$1"
 
+if [ -z "$ARCH" ]; then
+  echo "Error: architecture parameter is required." >&2
+  echo "Usage: $0 <arch>" >&2
+  exit 1
+fi
 uptime=$(awk '{print int($1)}' /proc/uptime)
 UP_JSON=$(jq -n \
   --arg arch "$ARCH" \

--- a/plugins/50_uptime_info.sh
+++ b/plugins/50_uptime_info.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Usage: 50_uptime_info.sh <arch>
+ARCH="$1"
+
+uptime=$(awk '{print int($1)}' /proc/uptime)
+UP_JSON=$(jq -n \
+  --arg arch "$ARCH" \
+  --arg uptime "$uptime" \
+  '{architecture: $arch, uptime_seconds: $uptime}')
+
+echo "$UP_JSON"

--- a/plugins/50_uptime_info.sh
+++ b/plugins/50_uptime_info.sh
@@ -7,7 +7,12 @@ if [ -z "$ARCH" ]; then
   echo "Usage: $0 <arch>" >&2
   exit 1
 fi
-uptime=$(awk '{print int($1)}' /proc/uptime)
+if [ -r /proc/uptime ] && [ -f /proc/uptime ]; then
+  uptime=$(awk '{print int($1)}' /proc/uptime)
+else
+  uptime="unknown"
+  echo "Warning: /proc/uptime is not readable or does not exist." >&2
+fi
 UP_JSON=$(jq -n \
   --arg arch "$ARCH" \
   --arg uptime "$uptime" \


### PR DESCRIPTION
This pull request adds a new script to report system uptime information in JSON format. The script takes an architecture argument and outputs the system's uptime in seconds, along with the architecture, using `jq`.

New uptime reporting script:

* Added `plugins/50_uptime_info.sh` to output system uptime and architecture as a JSON object, using `/proc/uptime` and `jq`.