### PR TITLE
Feature/uptime plugin

### DIFF
--- a/plugins/50_uptime_info.sh
+++ b/plugins/50_uptime_info.sh
@@ -1,21 +1,9 @@
-#!/usr/bin/env bash
-# Usage: 50_uptime_info.sh <arch>
-ARCH="$1"
+#!/bin/bash
 
-if [ -z "$ARCH" ]; then
-  echo "Error: architecture parameter is required." >&2
-  echo "Usage: $0 <arch>" >&2
-  exit 1
-fi
-if [ -r /proc/uptime ] && [ -f /proc/uptime ]; then
-  uptime=$(awk '{print int($1)}' /proc/uptime)
-else
-  uptime="unknown"
-  echo "Warning: /proc/uptime is not readable or does not exist." >&2
-fi
-UP_JSON=$(jq -n \
-  --arg arch "$ARCH" \
-  --arg uptime "$uptime" \
-  '{architecture: $arch, uptime_seconds: $uptime}')
+# Bash uptime plugin
 
-echo "$UP_JSON"
+uptime_info() {
+    uptime | awk -F'up ' '{ print $2 }' | awk -F',' '{ print $1 }'
+}
+
+uptime_info

--- a/test/plugins/50_uptime_info.bats
+++ b/test/plugins/50_uptime_info.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+setup() {
+  PLUGIN="plugins/50_uptime_info.sh"
+}
+
+@test "plugin outputs valid JSON given architecture" {
+  run bash "$PLUGIN" "x86_64"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq . > /dev/null
+}
+
+@test "plugin architecture field equals input" {
+  run bash "$PLUGIN" "arm64"
+  arch=$(echo "$output" | jq -r .architecture)
+  [ "$arch" = "arm64" ]
+}
+
+@test "plugin uptime_seconds is an integer and matches /proc/uptime" {
+  run bash "$PLUGIN" "testarch"
+  uptime=$(cat /proc/uptime | awk '{print int($1)}')
+  plugin_uptime=$(echo "$output" | jq -r .uptime_seconds)
+  [[ "$plugin_uptime" =~ ^[0-9]+$ ]]
+  [ "$plugin_uptime" -eq "$uptime" ]
+}


### PR DESCRIPTION
This pull request refactors the `50_uptime_info.sh` plugin to simplify its implementation and updates its functionality. The script now directly outputs a human-readable uptime value instead of JSON, and removes the architecture parameter requirement. Additionally, new Bats tests are introduced to validate the plugin's output format and correctness.

Refactor and simplification of uptime plugin:

* [`plugins/50_uptime_info.sh`](diffhunk://#diff-94c5764d7d5864c70f58f825ef3c978b7db88c7a96c6cb1b935d32a1824248e8L1-R9): Removed JSON output and architecture parameter, and simplified the script to directly print the uptime in a human-readable format.

Testing improvements:

* [`test/plugins/50_uptime_info.bats`](diffhunk://#diff-f8d203b79419bd4a0b9197de38a5ede8d00ff437765ec989bb950bf7250c3774R1-R25): Added Bats tests to verify the plugin's output format and correctness, including checks for valid JSON, architecture field, and uptime value.