### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_test_suite.yml
+++ b/.github/workflows/ci_test_suite.yml
@@ -1,5 +1,8 @@
 name: CI Test Suite for collect_info.sh
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/nullroute-commits/Automation_nation/security/code-scanning/1](https://github.com/nullroute-commits/Automation_nation/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/ci_test_suite.yml`. This block should be placed at the top level (before `jobs:`) to apply to all jobs, unless a job needs more specific permissions. The minimal required permission for most CI workflows is `contents: read`, which allows jobs to read repository contents but not modify them. If any job requires additional permissions (e.g., to interact with issues or pull requests), those can be added as needed, but for this workflow, `contents: read` is sufficient. No changes to the steps or job definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
